### PR TITLE
present checks ''(empty string) as well as null and undefined#

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Possible validations so far (true case in comments):
     iz.ofType(obj, typeName);         // If it is a named object, and the name matches the string
     iz.phone(str, canHaveExtension?); // Is an american phone number. Any punctuations are allowed.
     iz.postal(*);                     // Is a postal code or zip code
-    iz.present(*);                    // Is not null or undefined
+    iz.present(*);                    // Is not null, undefined or an empty string
     iz.ssn(*);                        // Is a social security number
 
 Almost all possible use cases that will definitely work (and definitely not work) are in the spec folder.

--- a/spec/validators.spec.js
+++ b/spec/validators.spec.js
@@ -340,11 +340,11 @@ describe("Validation", function () {
     it("can validate presence", function() {
         iz.present(null).should.not.be.ok;
         iz.present(undefined).should.not.be.ok;
+        iz.present('').should.not.be.ok;
         iz.present({}).should.be.ok;
         iz.present(function () {}).should.be.ok;
         iz.present([]).should.be.ok;
         iz.present(5).should.be.ok;
         iz.present(new Date()).should.be.ok;
-        iz.present('').should.be.ok;
     });
 });

--- a/src/validators.js
+++ b/src/validators.js
@@ -344,7 +344,7 @@
     }
 
     function iz_present(obj) {
-        return obj !== undefined && obj !== null;
+        return obj !== undefined && obj !== null && obj !== '';
     }
 
     //Expose some methods, this is done to preserve function names in all browsers


### PR DESCRIPTION
Was achieving this using iz.(stringValue).present().not().blank() but having used a lot through the day increasingly felt that iz(stringValue).present() was a natural syntax for a mandatory string field
