### PR TITLE
All validators return false for null & undefined (almost all)

### DIFF
--- a/spec/validators.spec.js
+++ b/spec/validators.spec.js
@@ -16,6 +16,8 @@ describe("Validation", function () {
         iz.alphaNumeric({}).should.not.be.ok;
         iz.alphaNumeric(function () {}).should.not.be.ok;
         iz.alphaNumeric([]).should.not.be.ok;
+        iz.alphaNumeric(null).should.not.be.ok;
+        iz.alphaNumeric(undefined).should.not.be.ok;
     });
 
     it("can validate that a primitive is between 2 other primitives", function () {
@@ -30,6 +32,8 @@ describe("Validation", function () {
         iz.between([1, 2], [1], [1, 4]).should.not.be.ok; //default array comparison... this is false.
         iz.between({},{},{}).should.not.be.ok; //it hates objects
         iz.between(function (){}, function (){}, function () {}).should.not.be.ok; //it also despises functions
+        iz.between(null, 1, 5).should.not.be.ok;
+        iz.between(undefined, 1, 5).should.not.be.ok;
     });
 
     it("can validate boolean values", function () {
@@ -41,6 +45,8 @@ describe("Validation", function () {
         iz.boolean("deadbeef").should.not.be.ok;
         iz.boolean("*").should.not.be.ok;
         iz.boolean(/[ \-]/g).should.not.be.ok;
+        iz.boolean(null).should.not.be.ok;
+        iz.boolean(undefined).should.not.be.ok;
     });
 
     it('can validate blank values', function() {
@@ -81,6 +87,8 @@ describe("Validation", function () {
         iz.cc({}).should.not.be.ok;
         iz.cc(function () {}).should.not.be.ok;
         iz.cc(["5"]).should.not.be.ok;
+        iz.cc(null).should.not.be.ok;
+        iz.cc(undefined).should.not.be.ok;
     });
 
     it("can validated dates", function () {
@@ -93,6 +101,8 @@ describe("Validation", function () {
         iz.date({}).should.not.be.ok;
         iz.date(function () {}).should.not.be.ok;
         iz.date([]).should.not.be.ok;
+        iz.date(null).should.not.be.ok;
+        iz.date(undefined).should.not.be.ok;
     });
 
     it("can validate decimals", function () {
@@ -106,6 +116,8 @@ describe("Validation", function () {
         iz.decimal({}).should.not.be.ok;
         iz.decimal(function () {}).should.not.be.ok;
         iz.decimal([]).should.not.be.ok;
+        iz.decimal(null).should.not.be.ok;
+        iz.decimal(undefined).should.not.be.ok;
     });
 
     it("can validate email address", function () {
@@ -116,6 +128,8 @@ describe("Validation", function () {
         iz.email(function () {}).should.not.be.ok;
         iz.email([]).should.not.be.ok;
         iz.email(5).should.not.be.ok;
+        iz.email(null).should.not.be.ok;
+        iz.email(undefined).should.not.be.ok;
     });
 
     it("can validate that something is empty", function () {
@@ -126,6 +140,8 @@ describe("Validation", function () {
         iz.empty(5).should.be.ok;
         iz.empty({bob: true}).should.not.be.ok;
         iz.empty(["hi"]).should.not.be.ok;
+        iz.empty(null).should.not.be.ok;
+        iz.empty(undefined).should.not.be.ok;
     });
 
     it("can validate that 2 things are strictly equal", function () {
@@ -190,21 +206,29 @@ describe("Validation", function () {
         iz.fileExtension("hello.png", [".png"]).should.not.be.ok;
         iz.fileExtension("hello.mp3", ["png"]).should.not.be.ok;
         iz.fileExtension({},{}).should.not.be.ok;
+        iz.fileExtension(null).should.not.be.ok;
+        iz.fileExtension(undefined).should.not.be.ok;
     });
 
     it("can validate audio file extensions", function () {
         iz.fileExtensionAudio("apple.mp3").should.be.ok;
         iz.fileExtensionAudio("apple.png").should.not.be.ok;
+        iz.fileExtensionAudio(null).should.not.be.ok;
+        iz.fileExtensionAudio(undefined).should.not.be.ok;
     });
 
     it("can validate image file extensions", function () {
         iz.fileExtensionImage("apple.png").should.be.ok;
         iz.fileExtensionImage("apple.mp3").should.not.be.ok;
+        iz.fileExtensionImage(null).should.not.be.ok;
+        iz.fileExtensionImage(undefined).should.not.be.ok;
     });
 
     it("can validate video file extensions", function () {
         iz.fileExtensionVideo("apple.mp4").should.be.ok;
         iz.fileExtensionVideo("apple.mp3").should.not.be.ok;
+        iz.fileExtensionVideo(null).should.not.be.ok;
+        iz.fileExtensionVideo(undefined).should.not.be.ok;
     });
 
     it("can tell if something is in an array", function () {
@@ -227,6 +251,8 @@ describe("Validation", function () {
         iz.int({}).should.not.be.ok;
         iz.int([]).should.not.be.ok;
         iz.int(function () {}).should.not.be.ok;
+        iz.int(null).should.not.be.ok;
+        iz.int(undefined).should.not.be.ok;
     });
 
     it("can validate IPv4, IPv6 and host names", function () {
@@ -244,6 +270,8 @@ describe("Validation", function () {
         iz.ip("0xC00002EB").should.not.be.ok;
         iz.ip("3221226219").should.not.be.ok;
         iz.ip("030000001353").should.not.be.ok;
+        iz.ip(null).should.not.be.ok;
+        iz.ip(undefined).should.not.be.ok;
     });
 
     it("can require a string to have some min length", function () {
@@ -252,12 +280,16 @@ describe("Validation", function () {
         iz.minLength("pizza", 6).should.not.be.ok;
         iz.minLength({}, 5).should.not.be.ok;
         iz.minLength("lizard", {}).should.not.be.ok;
+        iz.minLength(null).should.not.be.ok;
+        iz.minLength(undefined).should.not.be.ok;
     });
 
     it("can require an array to have some min length", function () {
         iz.minLength([1, 2, 3, 4, 5, 6], 6).should.be.ok;
         iz.minLength([1, 2, 3, 4, 5, 6], 5).should.be.ok;
         iz.minLength([1, 2, 3, 4, 5, 6], 7).should.not.be.ok;
+        iz.minLength(null).should.not.be.ok;
+        iz.minLength(undefined).should.not.be.ok;
     });
 
     it("can require a string to have some max length", function () {
@@ -266,12 +298,16 @@ describe("Validation", function () {
         iz.maxLength("pizza", 4).should.not.be.ok;
         iz.maxLength({}, 5).should.not.be.ok;
         iz.maxLength("lizard", {}).should.not.be.ok;
+        iz.maxLength(null).should.not.be.ok;
+        iz.maxLength(undefined).should.not.be.ok;
     });
 
     it("can require an array to have some max length", function () {
         iz.maxLength([1, 2, 3, 4, 5, 6], 6).should.be.ok;
         iz.maxLength([1, 2, 3, 4, 5, 6], 7).should.be.ok;
         iz.maxLength([1, 2, 3, 4, 5, 6], 5).should.not.be.ok;
+        iz.maxLength(null).should.not.be.ok;
+        iz.maxLength(undefined).should.not.be.ok;
     });
 
     it("can tell if a number is multiple of another number", function () {
@@ -279,6 +315,8 @@ describe("Validation", function () {
         iz.multiple(10, 2).should.be.ok;
         iz.multiple(2, 10).should.not.be.ok;
         iz.multiple(5, {}).should.not.be.ok; // disallow everything but numbers
+        iz.multiple(null).should.not.be.ok;
+        iz.multiple(undefined).should.not.be.ok;
     });
 
     it("can tell if something is a number", function () {
@@ -287,6 +325,8 @@ describe("Validation", function () {
         iz.number("5.32342").should.be.ok;
         iz.number(23123).should.be.ok;
         iz.number("bob").should.not.be.ok;
+        iz.number(null).should.not.be.ok;
+        iz.number(undefined).should.not.be.ok;
     });
 
     it("can tell if the name of an object is equal to some string", function () {
@@ -297,6 +337,8 @@ describe("Validation", function () {
         iz.ofType(new Car(), "Car").should.be.ok;
         iz.ofType(new Car(), "Object").should.not.be.ok;
         iz.ofType(obj, "Object").should.be.ok;
+        iz.ofType(null).should.not.be.ok;
+        iz.ofType(undefined).should.not.be.ok;
     });
 
     it("can validate a north american phone number", function () {
@@ -313,6 +355,8 @@ describe("Validation", function () {
 
         iz.phone("1234567890").should.be.ok;
         iz.phone("12345678901").should.be.ok;
+        iz.phone(null).should.not.be.ok;
+        iz.phone(undefined).should.not.be.ok;
     });
 
     it("can validate a US zip-code", function () {
@@ -324,6 +368,8 @@ describe("Validation", function () {
         iz.postal("94117-3333").should.be.ok;
         iz.postal("94117 33333").should.not.be.ok;
         iz.postal("9411").should.not.be.ok;
+        iz.postal(null).should.not.be.ok;
+        iz.postal(undefined).should.not.be.ok;
     });
 
     it("can validate a US SSN", function () {
@@ -335,6 +381,8 @@ describe("Validation", function () {
 
         iz.ssn("1234567890").should.not.ok;
         iz.ssn("123-45-678").should.not.be.ok;
+        iz.ssn(null).should.not.be.ok;
+        iz.ssn(undefined).should.not.be.ok;
     });
 
     it("can validate presence", function() {

--- a/src/validators.js
+++ b/src/validators.js
@@ -347,34 +347,41 @@
         return obj !== undefined && obj !== null;
     }
 
+
+    function iz_present_and(validator) {
+        return function(val) {
+            return iz_present(val) && validator.apply(this, Array.prototype.slice.call(arguments));
+        };
+    }
+
     //Expose some methods, this is done to preserve function names in all browsers
-    validators.alphaNumeric = iz_alphaNumeric;
-    validators.between = iz_between;
-    validators.blank = iz_blank;
-    validators.boolean = iz_boolean;
-    validators.cc = iz_cc;
-    validators.date = iz_date;
-    validators.decimal = iz_decimal;
-    validators.email = iz_email;
-    validators.empty = iz_empty;
-    validators.equal = iz_equal;
+    validators.alphaNumeric = iz_present_and(iz_alphaNumeric);
+    validators.between = iz_present_and(iz_between);
+    validators.blank = iz_present_and(iz_blank);
+    validators.boolean = iz_present_and(iz_boolean);
+    validators.cc = iz_present_and(iz_cc);
+    validators.date = iz_present_and(iz_date);
+    validators.decimal = iz_present_and(iz_decimal);
+    validators.email = iz_present_and(iz_email);
+    validators.empty = iz_present_and(iz_empty);
+    validators.equal = iz_present_and(iz_equal);
     validators.extension = iz_extension;
-    validators.fileExtension = iz_fileExtension;
-    validators.fileExtensionAudio = iz_fileExtensionAudio;
-    validators.fileExtensionImage = iz_fileExtensionImage;
-    validators.fileExtensionVideo = iz_fileExtensionVideo;
+    validators.fileExtension = iz_present_and(iz_fileExtension);
+    validators.fileExtensionAudio = iz_present_and(iz_fileExtensionAudio);
+    validators.fileExtensionImage = iz_present_and(iz_fileExtensionImage);
+    validators.fileExtensionVideo = iz_present_and(iz_fileExtensionVideo);
     validators.inArray = iz_inArray;
-    validators.int = iz_int;
-    validators.ip = iz_ip;
-    validators.minLength = iz_minLength;
-    validators.maxLength = iz_maxLength;
-    validators.multiple = iz_multiple;
-    validators.number = iz_number;
-    validators.ofType = iz_ofType;
-    validators.phone = iz_phone;
-    validators.postal = iz_postal;
-    validators.ssn = iz_ssn;
+    validators.int = iz_present_and(iz_int);
+    validators.ip = iz_present_and(iz_ip);
+    validators.minLength = iz_present_and(iz_minLength);
+    validators.maxLength = iz_present_and(iz_maxLength);
+    validators.multiple = iz_present_and(iz_multiple);
+    validators.number = iz_present_and(iz_number);
+    validators.ofType = iz_present_and(iz_ofType);
+    validators.phone = iz_present_and(iz_phone);
+    validators.postal = iz_present_and(iz_postal);
     validators.present = iz_present;
+    validators.ssn = iz_present_and(iz_ssn);
 
 
     // Export module


### PR DESCRIPTION
Please note: This request modifies existing behaviour.

Found some inconsistency in the output of the various validators when handling null and undefined. In general they all return false; however the following inconsistencies were found:

alphaNumeric, date & ip all return true rather than false
empty, ofType, minLength x 2 & maxLength x 2 all throw exceptions.

In all cases they now return false.

There has been no change to iz_extension as this is not actually testing the value of the argument. i.e. iz_extension(null, null) is perfectly valid if fairly pointless.

There has also been no change to iz_inArray. Again, no reason why iz_inArray(null, [null, "a string", 2]) should not be allowed.
