### PR TITLE
parse full validator stack for Are

### DIFF
--- a/src/are.js
+++ b/src/are.js
@@ -109,7 +109,7 @@ var iz = require('./iz');
                        return false;
                    }
                    valid = false;
-                   self._errors[key] = self._fields[key].errors;
+                   self._errors[field] = self._fields[field].errors;
                 }
             }
 


### PR DESCRIPTION
On scenarios for user interface validation, there are scenarios where it is preferable to have a full error stack displayed to user, than to have errors parsed and displayed one by one. 
