### PR TITLE
 Allow Iz to be Proxy "Polyfill-able"

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ Add nested error rules within are. The current implementation doesn't allow for 
 Change Log
 ====
 
+2.2.4
+----
+- Issue #44 - Iz should be proxy polyfill compatible (IE11 support)
+
 2.2.3
 ----
 - Issues #41/#42 - izEqual should accept null values

--- a/example/client.html
+++ b/example/client.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Iz Client Test</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script src="https://cdn.jsdelivr.net/npm/proxy-polyfill@0.2.0/proxy.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/es6-promise/4.1.1/es6-promise.auto.min.js"></script>
+  <script>window.module = {};</script>
+  <script src="/lib/iz.js"></script>
+</head>
+<body>
+  <script>
+    window.onload = function() {
+      iz.register({
+        truthy: function (val) { return !!val; },
+      });
+
+      console.log('Value', iz(5).truthy().valid);
+    };
+  </script>
+</body>
+</html>

--- a/src/iz.js
+++ b/src/iz.js
@@ -80,14 +80,27 @@ const proxyHandler = {
  * @return {Object} of type Iz
  */
 function iz(value, errorMessages) {
-  return new Proxy({
+  const target = {
     errors: [],
     errorMessages: errorMessages || {},
     promises: [],
     required: false,
     valid: true,
     value,
-  }, proxyHandler);
+
+    // We need all properties that could be used to be defined in order for polyfills to be effective.
+    // The following 2 are valid things that can be called.
+    isIz: null,
+    async: null,
+  };
+
+  // We need all properties that could be used to be defined in order for polyfills to be effective.
+  // All validators are properties that can be called
+  Object.keys(validators).forEach((key) => {
+    target[key] = null;
+  });
+
+  return new Proxy(target, proxyHandler);
 }
 
 function registerValidator(name, func, force) {


### PR DESCRIPTION
Proxy polyfills require that all properties be present at the time of
creation. This is a bit unfortunate, but not the worst thing in the
world.