### PR TITLE
Fix #47 - non-required are rules were not working

### DIFF
--- a/spec/are.spec.js
+++ b/spec/are.spec.js
@@ -129,6 +129,23 @@ describe('Are', function() {
     });
   });
 
+  describe('non-required fields', function() {
+    it('correctly validates', async function() {
+      this.rules = {
+        theDate: [
+          {
+            'rule': 'date',
+            'error': 'It is not a date!'
+          },
+        ],
+      };
+
+      this.obj = {};
+      const result = are(this.rules).for(this.obj);
+      result.valid.should.eql(true);
+    });
+  });
+
   describe('validation passes for Are rules', function() {
     it('correctly validates', async function() {
       this.rules = {

--- a/spec/iz.spec.js
+++ b/spec/iz.spec.js
@@ -56,10 +56,16 @@ describe('Iz', function() {
     iz(5).between(4, 6).notIp().int().valid.should.be.true();
   });
 
-  it('handles required/non-required values', function () {
-    iz('').between(4, 6).valid.should.be.false();
-    iz(null).between(4, 6).valid.should.be.false();
-    iz(undefined).between(4, 6).valid.should.be.false();
+  it('handles non-required values', function () {
+    iz('').between(4, 6).valid.should.be.true();
+    iz(null).between(4, 6).valid.should.be.true();
+    iz(undefined).between(4, 6).valid.should.be.true();
+
+
+    iz('').between(4, 6).required().valid.should.be.false();
+    iz(null).between(4, 6).required().valid.should.be.false();
+    iz(undefined).between(4, 6).required().valid.should.be.false();
+
     iz(3).between(4, 6).valid.should.be.false();
     iz(5).between(4, 6).valid.should.be.true();
   });

--- a/src/iz.js
+++ b/src/iz.js
@@ -22,7 +22,7 @@ function captureError(target, name, isNotted, result, allArgs) {
 }
 
 function getValid(target) {
-  if (!target.required && [undefined, null, ''].indexOf(target.valid) > -1) {
+  if (!target.required && [undefined, null, ''].indexOf(target.value) > -1) {
     return true;
   }
   return target.valid;

--- a/src/utils/nameOfClass.js
+++ b/src/utils/nameOfClass.js
@@ -1,4 +1,6 @@
 module.exports = function izGetObjectClass(obj) {
+  if (typeof obj === 'undefined') { return undefined; }
+
   // Custom displayName class name (i've seen this standard around)
   // This could work for minified code. Check out the babel display name plugin
   if (obj.constructor && obj.constructor.displayName) {


### PR DESCRIPTION
I think this was caused by a typo that sometimes resulted in decent
results. This was likely caused by the last refactor.